### PR TITLE
Add toJSON method

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -166,6 +166,8 @@ The <dfn attribute>lastPaintedElement</dfn> attribute must return the value of [
 
 The <dfn attribute>rootElement</dfn> attribute must return the value of [=this=]'s [=ContainerTiming/rootElement=].
 
+When {{PerformanceContainerTiming/toJSON()}} is called, run [=default toJSON steps=].
+
 </div>
 
 Note: The user agent needs to maintain the <a>container root records map</a> so that removed content does not introduce memory leaks. In particular, it can tie the lifetime of the entries to weak pointers to the {{HTMLElement}}s so that they can be cleaned up sometime after the {{HTMLElement}}s are removed. Since the map is not exposed to web developers, this does not expose garbage collection timing.

--- a/index.bs
+++ b/index.bs
@@ -127,6 +127,8 @@ interface PerformanceContainerTiming : PerformanceEntry {
     readonly attribute DOMHighResTimeStamp firstRenderTime;
     readonly attribute HTMLElement? lastPaintedElement;
     readonly attribute HTMLElement? rootElement;
+
+    [Default] object toJSON();
 };
 
 PerformanceContainerTiming includes PaintTimingMixin;


### PR DESCRIPTION
Fixes #70 

I've confirmed that both Chrome and Firefox implement this override currently instead of just using the default parent PerformanceEntry `toJSON()` method.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tunetheweb/container-timing/pull/77.html" title="Last updated on Sep 8, 2026, 12:28 PM UTC (f630caf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/container-timing/77/b5c44a1...tunetheweb:f630caf.html" title="Last updated on Sep 8, 2026, 12:28 PM UTC (f630caf)">Diff</a>